### PR TITLE
Fix output formatting in guessing game

### DIFF
--- a/guessing_game/src/main.rs
+++ b/guessing_game/src/main.rs
@@ -18,16 +18,16 @@ fn main() {
         let u_guess: u16 = match guess.trim().parse() {
             Ok(num) => num,
             Err(_) => {
-                println!("{guess} is not a valid number.");
+                println!("{guess} is not a valid number.", guess = guess.trim());
                 continue;
             }
         };
 
         match u_guess.cmp(&secret) {
-            Ordering::Less => print!("too small!!"),
+            Ordering::Less => println!("too small!!"),
             Ordering::Greater => println!("too big!!"),
             Ordering::Equal => {
-                println!("you guessed it, it's {guess}");
+                println!("you guessed it, it's {u_guess}");
                 break;
             },
         }


### PR DESCRIPTION
## Summary
- improve user feedback in guessing game example by removing newline issues

## Testing
- `cargo check` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_68561581b4348323887c288a97e22bec